### PR TITLE
Added Gentoo support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -154,9 +154,48 @@ __Debian:__
 }
 ```
 
+__Gentoo:__
+
+```ruby
+{
+'FAIL_DELAY'       => '3'
+'LOG_UNKFAIL_ENAB' => 'no'
+'LOG_OK_LOGINS'    => 'no'
+'SYSLOG_SU_ENAB'   => 'yes'
+'SYSLOG_SG_ENAB'   => 'yes'
+'CONSOLE'          => '/etc/securetty'
+'SU_NAME'          => 'su'
+'MAIL_DIR'         => '/var/spool/mail'
+'HUSHLOGIN_FILE'   => '.hushlogin'
+'ENV_SUPATH'       => 'PATH=/sbin:/bin:/usr/sbin:/usr/bin'
+'ENV_PATH'         => 'PATH=/bin:/usr/bin'
+'TTYGROUP'         => 'tty'
+'TTYPERM'          => '0600'
+'ERASECHAR'        => '0177'
+'KILLCHAR'         => '025'
+'UMASK'            => '022'
+'PASS_MAX_DAYS'    => '99999'
+'PASS_MIN_DAYS'    => '0'
+'PASS_WARN_AGE'    => '7'
+'UID_MIN'          => '1000'
+'UID_MAX'          => '60000'
+'SYS_UID_MIN'      => '101'
+'SYS_UID_MAX'      => '999'
+'GID_MIN'          => '1000'
+'GID_MAX'          => '60000'
+'SYS_GID_MIN'      => '101'
+'SYS_GID_MAX'      => '999'
+'LOGIN_RETRIES'    => '5'
+'LOGIN_TIMEOUT'    => '60'
+'CHFN_RESTRICT'    => 'rwh'
+'DEFAULT_HOME'     => 'yes'
+'USERGROUPS_ENAB'  => 'yes'
+}
+```
+
 ## Limitations
 
-Only supports RedHat and Debian family operating systems right now.
+Only supports RedHat, Debian and Gentoo family operating systems right now.
 
 ## Authors
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -114,7 +114,7 @@ class login_defs::params {
         'CHFN_RESTRICT'    => 'rwh',
         'DEFAULT_HOME'     => 'yes',
         'USERGROUPS_ENAB'  => 'yes',
-      }',
+      }'
     }
     default: {
       fail("${::osfamily} not supported by ${module_name}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -82,39 +82,39 @@ class login_defs::params {
     }
     'Gentoo': {
       $default_options = {
-        'FAIL_DELAY'       => '3'
-        'LOG_UNKFAIL_ENAB' => 'no'
-        'LOG_OK_LOGINS'    => 'no'
-        'SYSLOG_SU_ENAB'   => 'yes'
-        'SYSLOG_SG_ENAB'   => 'yes'
-        'CONSOLE'          => '/etc/securetty'
-        'SU_NAME'          => 'su'
-        'MAIL_DIR'         => '/var/spool/mail'
-        'HUSHLOGIN_FILE'   => '.hushlogin'
-        'ENV_SUPATH'       => 'PATH=/sbin:/bin:/usr/sbin:/usr/bin'
-        'ENV_PATH'         => 'PATH=/bin:/usr/bin'
-        'TTYGROUP'         => 'tty'
-        'TTYPERM'          => '0600'
-        'ERASECHAR'        => '0177'
-        'KILLCHAR'         => '025'
-        'UMASK'            => '022'
-        'PASS_MAX_DAYS'    => '99999'
-        'PASS_MIN_DAYS'    => '0'
-        'PASS_WARN_AGE'    => '7'
-        'UID_MIN'          => '1000'
-        'UID_MAX'          => '60000'
-        'SYS_UID_MIN'      => '101'
-        'SYS_UID_MAX'      => '999'
-        'GID_MIN'          => '1000'
-        'GID_MAX'          => '60000'
-        'SYS_GID_MIN'      => '101'
-        'SYS_GID_MAX'      => '999'
-        'LOGIN_RETRIES'    => '5'
-        'LOGIN_TIMEOUT'    => '60'
-        'CHFN_RESTRICT'    => 'rwh'
-        'DEFAULT_HOME'     => 'yes'
-        'USERGROUPS_ENAB'  => 'yes'
-      }'
+        'FAIL_DELAY'       => '3',
+        'LOG_UNKFAIL_ENAB' => 'no',
+        'LOG_OK_LOGINS'    => 'no',
+        'SYSLOG_SU_ENAB'   => 'yes',
+        'SYSLOG_SG_ENAB'   => 'yes',
+        'CONSOLE'          => '/etc/securetty',
+        'SU_NAME'          => 'su',
+        'MAIL_DIR'         => '/var/spool/mail',
+        'HUSHLOGIN_FILE'   => '.hushlogin',
+        'ENV_SUPATH'       => 'PATH=/sbin:/bin:/usr/sbin:/usr/bin',
+        'ENV_PATH'         => 'PATH=/bin:/usr/bin',
+        'TTYGROUP'         => 'tty',
+        'TTYPERM'          => '0600',
+        'ERASECHAR'        => '0177',
+        'KILLCHAR'         => '025',
+        'UMASK'            => '022',
+        'PASS_MAX_DAYS'    => '99999',
+        'PASS_MIN_DAYS'    => '0',
+        'PASS_WARN_AGE'    => '7',
+        'UID_MIN'          => '1000',
+        'UID_MAX'          => '60000',
+        'SYS_UID_MIN'      => '101',
+        'SYS_UID_MAX'      => '999',
+        'GID_MIN'          => '1000',
+        'GID_MAX'          => '60000',
+        'SYS_GID_MIN'      => '101',
+        'SYS_GID_MAX'      => '999',
+        'LOGIN_RETRIES'    => '5',
+        'LOGIN_TIMEOUT'    => '60',
+        'CHFN_RESTRICT'    => 'rwh',
+        'DEFAULT_HOME'     => 'yes',
+        'USERGROUPS_ENAB'  => 'yes',
+      }',
     }
     default: {
       fail("${::osfamily} not supported by ${module_name}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,6 +80,42 @@ class login_defs::params {
         'USERGROUPS_ENAB'  => 'yes',
       }
     }
+    'Gentoo': {
+      $default_options = {
+        'FAIL_DELAY'       => '3'
+        'LOG_UNKFAIL_ENAB' => 'no'
+        'LOG_OK_LOGINS'    => 'no'
+        'SYSLOG_SU_ENAB'   => 'yes'
+        'SYSLOG_SG_ENAB'   => 'yes'
+        'CONSOLE'          => '/etc/securetty'
+        'SU_NAME'          => 'su'
+        'MAIL_DIR'         => '/var/spool/mail'
+        'HUSHLOGIN_FILE'   => '.hushlogin'
+        'ENV_SUPATH'       => 'PATH=/sbin:/bin:/usr/sbin:/usr/bin'
+        'ENV_PATH'         => 'PATH=/bin:/usr/bin'
+        'TTYGROUP'         => 'tty'
+        'TTYPERM'          => '0600'
+        'ERASECHAR'        => '0177'
+        'KILLCHAR'         => '025'
+        'UMASK'            => '022'
+        'PASS_MAX_DAYS'    => '99999'
+        'PASS_MIN_DAYS'    => '0'
+        'PASS_WARN_AGE'    => '7'
+        'UID_MIN'          => '1000'
+        'UID_MAX'          => '60000'
+        'SYS_UID_MIN'      => '101'
+        'SYS_UID_MAX'      => '999'
+        'GID_MIN'          => '1000'
+        'GID_MAX'          => '60000'
+        'SYS_GID_MIN'      => '101'
+        'SYS_GID_MAX'      => '999'
+        'LOGIN_RETRIES'    => '5'
+        'LOGIN_TIMEOUT'    => '60'
+        'CHFN_RESTRICT'    => 'rwh'
+        'DEFAULT_HOME'     => 'yes'
+        'USERGROUPS_ENAB'  => 'yes'
+      }'
+    }
     default: {
       fail("${::osfamily} not supported by ${module_name}")
     }

--- a/metadata.json
+++ b/metadata.json
@@ -56,7 +56,7 @@
         "12.04",
         "14.04"
       ]
-    }
+    },
     {
       "operatingsystem": "Gentoo"
     }

--- a/metadata.json
+++ b/metadata.json
@@ -57,5 +57,8 @@
         "14.04"
       ]
     }
+    {
+      "operatingsystem": "Gentoo"
+    }
   ]
 }


### PR DESCRIPTION
The params.pp and metadata.json has been rewritten to support also Gentoo OS.
login.defs params are from basesystem 2.3.