### PR TITLE
Add badges

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: Validation and Linting
+name: Validation
 
 on:
   - push

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # login_defs module for Puppet
 
-[![Build Status](https://travis-ci.org/joshbeard/puppet-login_defs.svg?branch=master)](https://travis-ci.org/joshbeard/puppet-login_defs)
+![Validation Status](https://github.com/joshbeard/puppet-login_defs/actions/workflows/validate.yml/badge.svg)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/joshbeard/login_defs.svg)](https://forge.puppetlabs.com/puppet/logrotate)
+[![License](https://img.shields.io/github/license/joshbeard/puppet-login_defs.svg)](https://github.com/joshbeard/puppet-login_defs/blob/master/LICENSE)
 
 Manages `/etc/login.defs` on Linux systems.
 


### PR DESCRIPTION
Add badges to README for validation status, puppet forge version, and
license.

Rename the GitHub workflow for validation.