### PR TITLE
docs: link to contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,4 @@ To add a distribution's default options:
 
 Maintained by [Josh Beard](https://joshbeard.me)
 
-<a href="https://github.com/joshbeard/puppet-login_defs/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=joshbeard/puppet-login_defs" />
-</a>
-
-_Made with [contributors-img](https://contrib.rocks)._
+See the list of [contributors](https://github.com/joshbeard/puppet-login_defs/graphs/contributors).


### PR DESCRIPTION
Rather than use an external image in the README, which doesn't show up on the Puppet Forge anyway, link to the contributors on GitHub.